### PR TITLE
Support "false" value for USE_SSH env var

### DIFF
--- a/packages/docusaurus/src/commands/deploy.ts
+++ b/packages/docusaurus/src/commands/deploy.ts
@@ -67,7 +67,7 @@ export async function deploy(siteDir: string): Promise<void> {
     process.env.GITHUB_HOST || siteConfig.githubHost || 'github.com';
 
   const useSSH = process.env.USE_SSH;
-  const remoteBranch = useSSH
+  const remoteBranch = (useSSH && useSSH.toLowerCase() !== 'false')
     ? `git@${githubHost}:${organizationName}/${projectName}.git`
     : `https://${gitUser}@${githubHost}/${organizationName}/${projectName}.git`;
 


### PR DESCRIPTION
## Motivation

Docusaurus 1.X treats any non-'true' value to be false, but Docusaurus 2.X currently treats any non-empty string to be truthy here. This change should unbreak projects that migrate from V1 to V2 with `USE_SSH=false` environment variables.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/facebook/docusaurus/blob/master/CONTRIBUTING.md#pull-requests)?

Yep!

## Test Plan

eyes
